### PR TITLE
Add cross-env to execute npm scripts on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "clean": "rimraf lib dist",
     "build": "babel src --out-dir lib",
-    "build:umd": "webpack src/index.js dist/react-matchmedia-connect.js && NODE_ENV=production webpack src/index.js dist/react-matchmedia-connect.min.js",
+    "build:umd": "webpack src/index.js dist/react-matchmedia-connect.js && cross-env NODE_ENV=production webpack src/index.js dist/react-matchmedia-connect.min.js",
     "lint": "eslint src test examples",
-    "test": "NODE_ENV=test karma start",
-    "test:watch": "NODE_ENV=test karma start --auto-watch --no-single-run",
-    "test:cov": "NODE_ENV=test COVERAGE=true karma start --single-run",
+    "test": "cross-env NODE_ENV=test karma start",
+    "test:watch": "cross-env NODE_ENV=test karma start --auto-watch --no-single-run",
+    "test:cov": "cross-env NODE_ENV=test COVERAGE=true karma start --single-run",
     "prepublish": "npm run lint && npm run test && npm run clean && npm run build"
   },
   "repository": {
@@ -42,6 +42,7 @@
     "babel-preset-stage-1": "^6.1.18",
     "babel-register": "^6.3.13",
     "babel-runtime": "^6.3.19",
+    "cross-env": "^1.0.7",
     "eslint": "^1.6.0",
     "eslint-config-airbnb": "^5.0.0",
     "eslint-plugin-react": "^3.5.1",


### PR DESCRIPTION
Some npm scripts were not running on windows because of NODE_ENV variable, so I added cross-env as dev dependency to fix it.
