### PR TITLE
Allow versions greater than 0.14.0 as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "webpack-dev-server": "^1.8.2"
   },
   "peerDependencies": {
-    "react": "^0.14.5",
-    "react-dom": "^0.14.5"
+    "react": ">=0.14.0",
+    "react-dom": ">=0.14.0"
   }
 }


### PR DESCRIPTION
We use react v15 in our project. Installment with npm v3.8.7  works fine, but throws a warning that peer dependencies are not matching. Further when using `npm shrinkwrap` it throws an error and will not create the file. 

Using react greater than 0.14.0 in package.js as peer dependency is working fine.
